### PR TITLE
Don't set last_target to ConfigDiff when target is empty

### DIFF
--- a/src/main/java/org/embulk/input/RemoteFileInputPlugin.java
+++ b/src/main/java/org/embulk/input/RemoteFileInputPlugin.java
@@ -177,6 +177,11 @@ public class RemoteFileInputPlugin
 
 		List<Target> targets = new ArrayList<>(task.getTargets());
 		Collections.sort(targets);
+
+		if (targets.isEmpty()) {
+			return Exec.newConfigDiff();
+		}
+
 		return Exec.newConfigDiff().set("last_target", targets.get(targets.size() - 1));
 	}
 


### PR DESCRIPTION
When all target host does not have file, "ArrayIndexOutOfBoundsException" raised
- stack trace

```
java.lang.ArrayIndexOutOfBoundsException: -1
    at java.util.ArrayList.elementData(java/util/ArrayList.java:418)
    at java.util.ArrayList.get(java/util/ArrayList.java:431)
    at org.embulk.input.RemoteFileInputPlugin.resume(org/embulk/input/RemoteFileInputPlugin.java:180)
    at org.embulk.input.RemoteFileInputPlugin.transaction(org/embulk/input/RemoteFileInputPlugin.java:94)
    at org.embulk.spi.FileInputRunner.transaction(org/embulk/spi/FileInputRunner.java:64)
    at org.embulk.exec.BulkLoader.doRun(org/embulk/exec/BulkLoader.java:477)
    at org.embulk.exec.BulkLoader.access$100(org/embulk/exec/BulkLoader.java:33)
    at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:339)
    at org.embulk.exec.BulkLoader$1.run(org/embulk/exec/BulkLoader.java:335)
    at org.embulk.spi.Exec.doWith(org/embulk/spi/Exec.java:25)
    at org.embulk.exec.BulkLoader.run(org/embulk/exec/BulkLoader.java:335)
    at org.embulk.EmbulkEmbed.run(org/embulk/EmbulkEmbed.java:179)
    at java.lang.reflect.Method.invoke(java/lang/reflect/Method.java:483)
    at RUBY.run(/usr/local/embulk/bin/embulk!/embulk/runner.rb:77)
    at RUBY.run(/usr/local/embulk/bin/embulk!/embulk/command/embulk_run.rb:278)
    at RUBY.<top>(/usr/local/embulk/bin/embulk!/embulk/command/embulk_main.rb:2)
    at org.jruby.RubyKernel.require(org/jruby/RubyKernel.java:940)
    at RUBY.(root)(uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1)
    at usr.local.embulk.bin.embulk.embulk.command.embulk_bundle.<top>(file:/usr/local/embulk/bin/embulk!/embulk/command/embulk_bundle.rb:55)
    at java.lang.invoke.MethodHandle.invokeWithArguments(java/lang/invoke/MethodHandle.java:636)
    at org.embulk.cli.Main.main(org/embulk/cli/Main.java:23)
```
